### PR TITLE
Add GET /lookups/ranges endpoint for lookup range brackets

### DIFF
--- a/Api/Api.Map/LookupRangeBracketMap.cs
+++ b/Api/Api.Map/LookupRangeBracketMap.cs
@@ -1,0 +1,15 @@
+using DomainObject = PayrollEngine.Domain.Model;
+using ApiObject = PayrollEngine.Api.Model;
+using Riok.Mapperly.Abstractions;
+
+namespace PayrollEngine.Api.Map;
+
+/// <summary>
+/// Map a domain object with an api object
+/// </summary>
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName, EnumMappingIgnoreCase = true)]
+public partial class LookupRangeBracketMap : ApiMapBase<DomainObject.LookupRangeBracket, ApiObject.LookupRangeBracket>
+{
+    public override partial ApiObject.LookupRangeBracket ToApi(DomainObject.LookupRangeBracket domainObject);
+    public override partial DomainObject.LookupRangeBracket ToDomain(ApiObject.LookupRangeBracket apiObject);
+}

--- a/Api/Api.Map/LookupRangeResultMap.cs
+++ b/Api/Api.Map/LookupRangeResultMap.cs
@@ -1,0 +1,15 @@
+using DomainObject = PayrollEngine.Domain.Model;
+using ApiObject = PayrollEngine.Api.Model;
+using Riok.Mapperly.Abstractions;
+
+namespace PayrollEngine.Api.Map;
+
+/// <summary>
+/// Map a domain object with an api object
+/// </summary>
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName, EnumMappingIgnoreCase = true)]
+public partial class LookupRangeResultMap : ApiMapBase<DomainObject.LookupRangeResult, ApiObject.LookupRangeResult>
+{
+    public override partial ApiObject.LookupRangeResult ToApi(DomainObject.LookupRangeResult domainObject);
+    public override partial DomainObject.LookupRangeResult ToDomain(ApiObject.LookupRangeResult apiObject);
+}

--- a/Api/Api.Model/LookupRangeBracket.cs
+++ b/Api/Api.Model/LookupRangeBracket.cs
@@ -1,0 +1,38 @@
+namespace PayrollEngine.Api.Model;
+
+/// <summary>
+/// A lookup range bracket with computed bounds
+/// </summary>
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+public class LookupRangeBracket
+{
+    /// <summary>
+    /// The lookup value key
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// The lookup value as JSON
+    /// </summary>
+    public string Value { get; set; }
+
+    /// <summary>
+    /// The range start (lower bound)
+    /// </summary>
+    public decimal LowerBound { get; set; }
+
+    /// <summary>
+    /// The range end (upper bound), null for unbounded last bracket
+    /// </summary>
+    public decimal? UpperBound { get; set; }
+
+    /// <summary>
+    /// The original range value from the lookup value
+    /// </summary>
+    public decimal? RangeValue { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"{Key}: {LowerBound} - {UpperBound}";
+}

--- a/Api/Api.Model/LookupRangeResult.cs
+++ b/Api/Api.Model/LookupRangeResult.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace PayrollEngine.Api.Model;
+
+/// <summary>
+/// Result of a lookup range bracket computation
+/// </summary>
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+public class LookupRangeResult
+{
+    /// <summary>
+    /// The lookup name
+    /// </summary>
+    public string LookupName { get; set; }
+
+    /// <summary>
+    /// The lookup range mode
+    /// </summary>
+    public LookupRangeMode RangeMode { get; set; }
+
+    /// <summary>
+    /// The lookup range size
+    /// </summary>
+    public decimal? RangeSize { get; set; }
+
+    /// <summary>
+    /// The matching bracket for threshold mode, null for progressive
+    /// </summary>
+    public LookupRangeBracket MatchingBracket { get; set; }
+
+    /// <summary>
+    /// All matching brackets for progressive mode, null for threshold
+    /// </summary>
+    public List<LookupRangeBracket> MatchingBrackets { get; set; }
+
+    /// <summary>
+    /// All range brackets
+    /// </summary>
+    public List<LookupRangeBracket> AllBrackets { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        LookupName;
+}

--- a/Api/Api.Model/PayrollEngine.Api.Model.xml
+++ b/Api/Api.Model/PayrollEngine.Api.Model.xml
@@ -2154,6 +2154,77 @@
         <member name="M:PayrollEngine.Api.Model.LookupData.ToString">
             <inheritdoc/>
         </member>
+        <member name="T:PayrollEngine.Api.Model.LookupRangeBracket">
+            <summary>
+            A lookup range bracket with computed bounds
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeBracket.Key">
+            <summary>
+            The lookup value key
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeBracket.Value">
+            <summary>
+            The lookup value as JSON
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeBracket.LowerBound">
+            <summary>
+            The range start (lower bound)
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeBracket.UpperBound">
+            <summary>
+            The range end (upper bound), null for unbounded last bracket
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeBracket.RangeValue">
+            <summary>
+            The original range value from the lookup value
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Api.Model.LookupRangeBracket.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="T:PayrollEngine.Api.Model.LookupRangeResult">
+            <summary>
+            Result of a lookup range bracket computation
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.LookupName">
+            <summary>
+            The lookup name
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.RangeMode">
+            <summary>
+            The lookup range mode
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.RangeSize">
+            <summary>
+            The lookup range size
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.MatchingBracket">
+            <summary>
+            The matching bracket for threshold mode, null for progressive
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.MatchingBrackets">
+            <summary>
+            All matching brackets for progressive mode, null for threshold
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Api.Model.LookupRangeResult.AllBrackets">
+            <summary>
+            All range brackets
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Api.Model.LookupRangeResult.ToString">
+            <inheritdoc/>
+        </member>
         <member name="T:PayrollEngine.Api.Model.LookupSet">
             <summary>
             Lookup including the lookup value

--- a/Backend.Controller/PayrollController.cs
+++ b/Backend.Controller/PayrollController.cs
@@ -740,6 +740,42 @@ public class PayrollController : Api.Controller.PayrollController
     }
 
     /// <summary>
+    /// Get payroll lookup range brackets
+    /// </summary>
+    /// <param name="tenantId">The tenant id</param>
+    /// <param name="payrollId">The payroll id</param>
+    /// <param name="lookupNames">The lookup names (case-insensitive)</param>
+    /// <param name="rangeValue">Optional value to find matching bracket(s)</param>
+    /// <param name="regulationDate">The regulation date (default: UTC now)</param>
+    /// <param name="evaluationDate">The evaluation date (default: UTC now)</param>
+    /// <param name="culture">The content culture</param>
+    /// <returns>The lookup range results</returns>
+    [HttpGet("{payrollId}/lookups/ranges")]
+    [OkResponse]
+    [NotFoundResponse]
+    [ApiOperationId("GetPayrollLookupRanges")]
+    public async Task<ActionResult<ApiObject.LookupRangeResult[]>> GetPayrollLookupRangesAsync(int tenantId, int payrollId,
+        [FromQuery][Required] string[] lookupNames, [FromQuery] decimal? rangeValue,
+        [FromQuery] DateTime? regulationDate, [FromQuery] DateTime? evaluationDate, [FromQuery] string culture)
+    {
+        // authorization
+        var authResult = await TenantRequestAsync(tenantId);
+        if (authResult != null)
+        {
+            return authResult;
+        }
+        return await base.GetPayrollLookupRangesAsync(
+            new()
+            {
+                TenantId = tenantId,
+                PayrollId = payrollId,
+                RegulationDate = regulationDate,
+                EvaluationDate = evaluationDate
+            },
+            lookupNames, rangeValue, culture);
+    }
+
+    /// <summary>
     /// Get payroll report sets
     /// </summary>
     /// <param name="tenantId">The tenant id</param>

--- a/Domain/Domain.Model/LookupRangeBracket.cs
+++ b/Domain/Domain.Model/LookupRangeBracket.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace PayrollEngine.Domain.Model;
+
+/// <summary>
+/// A lookup range bracket with computed bounds
+/// </summary>
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+public class LookupRangeBracket : IEquatable<LookupRangeBracket>
+{
+    /// <summary>
+    /// The lookup value key
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// The lookup value as JSON
+    /// </summary>
+    public string Value { get; set; }
+
+    /// <summary>
+    /// The range start (lower bound)
+    /// </summary>
+    public decimal LowerBound { get; set; }
+
+    /// <summary>
+    /// The range end (upper bound), null for unbounded last bracket
+    /// </summary>
+    public decimal? UpperBound { get; set; }
+
+    /// <summary>
+    /// The original range value from the lookup value
+    /// </summary>
+    public decimal? RangeValue { get; set; }
+
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public LookupRangeBracket()
+    {
+    }
+
+    /// <summary>
+    /// Copy constructor
+    /// </summary>
+    /// <param name="source">The source to copy</param>
+    public LookupRangeBracket(LookupRangeBracket source)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        Key = source.Key;
+        Value = source.Value;
+        LowerBound = source.LowerBound;
+        UpperBound = source.UpperBound;
+        RangeValue = source.RangeValue;
+    }
+
+    /// <summary>Compare two objects</summary>
+    /// <param name="compare">The object to compare with this</param>
+    /// <returns>True for objects with the same data</returns>
+    public bool Equals(LookupRangeBracket compare) =>
+        CompareTool.EqualProperties(this, compare);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"{Key}: {LowerBound} - {UpperBound}";
+}

--- a/Domain/Domain.Model/LookupRangeResult.cs
+++ b/Domain/Domain.Model/LookupRangeResult.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace PayrollEngine.Domain.Model;
+
+/// <summary>
+/// Result of a lookup range bracket computation
+/// </summary>
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+public class LookupRangeResult : IEquatable<LookupRangeResult>
+{
+    /// <summary>
+    /// The lookup name
+    /// </summary>
+    public string LookupName { get; set; }
+
+    /// <summary>
+    /// The lookup range mode
+    /// </summary>
+    public LookupRangeMode RangeMode { get; set; }
+
+    /// <summary>
+    /// The lookup range size
+    /// </summary>
+    public decimal? RangeSize { get; set; }
+
+    /// <summary>
+    /// The matching bracket for threshold mode, null for progressive
+    /// </summary>
+    public LookupRangeBracket MatchingBracket { get; set; }
+
+    /// <summary>
+    /// All matching brackets for progressive mode, null for threshold
+    /// </summary>
+    public List<LookupRangeBracket> MatchingBrackets { get; set; }
+
+    /// <summary>
+    /// All range brackets
+    /// </summary>
+    public List<LookupRangeBracket> AllBrackets { get; set; }
+
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public LookupRangeResult()
+    {
+    }
+
+    /// <summary>
+    /// Copy constructor
+    /// </summary>
+    /// <param name="source">The source to copy</param>
+    public LookupRangeResult(LookupRangeResult source)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        LookupName = source.LookupName;
+        RangeMode = source.RangeMode;
+        RangeSize = source.RangeSize;
+        MatchingBracket = source.MatchingBracket;
+        MatchingBrackets = source.MatchingBrackets;
+        AllBrackets = source.AllBrackets;
+    }
+
+    /// <summary>Compare two objects</summary>
+    /// <param name="compare">The object to compare with this</param>
+    /// <returns>True for objects with the same data</returns>
+    public bool Equals(LookupRangeResult compare) =>
+        CompareTool.EqualProperties(this, compare);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        LookupName;
+}

--- a/Domain/Domain.Model/PayrollEngine.Domain.Model.xml
+++ b/Domain/Domain.Model/PayrollEngine.Domain.Model.xml
@@ -4448,6 +4448,109 @@
         <member name="M:PayrollEngine.Domain.Model.LookupData.ToString">
             <inheritdoc/>
         </member>
+        <member name="T:PayrollEngine.Domain.Model.LookupRangeBracket">
+            <summary>
+            A lookup range bracket with computed bounds
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeBracket.Key">
+            <summary>
+            The lookup value key
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeBracket.Value">
+            <summary>
+            The lookup value as JSON
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeBracket.LowerBound">
+            <summary>
+            The range start (lower bound)
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeBracket.UpperBound">
+            <summary>
+            The range end (upper bound), null for unbounded last bracket
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeBracket.RangeValue">
+            <summary>
+            The original range value from the lookup value
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeBracket.#ctor">
+            <summary>
+            Default constructor
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeBracket.#ctor(PayrollEngine.Domain.Model.LookupRangeBracket)">
+            <summary>
+            Copy constructor
+            </summary>
+            <param name="source">The source to copy</param>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeBracket.Equals(PayrollEngine.Domain.Model.LookupRangeBracket)">
+            <summary>Compare two objects</summary>
+            <param name="compare">The object to compare with this</param>
+            <returns>True for objects with the same data</returns>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeBracket.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="T:PayrollEngine.Domain.Model.LookupRangeResult">
+            <summary>
+            Result of a lookup range bracket computation
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.LookupName">
+            <summary>
+            The lookup name
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.RangeMode">
+            <summary>
+            The lookup range mode
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.RangeSize">
+            <summary>
+            The lookup range size
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.MatchingBracket">
+            <summary>
+            The matching bracket for threshold mode, null for progressive
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.MatchingBrackets">
+            <summary>
+            All matching brackets for progressive mode, null for threshold
+            </summary>
+        </member>
+        <member name="P:PayrollEngine.Domain.Model.LookupRangeResult.AllBrackets">
+            <summary>
+            All range brackets
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeResult.#ctor">
+            <summary>
+            Default constructor
+            </summary>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeResult.#ctor(PayrollEngine.Domain.Model.LookupRangeResult)">
+            <summary>
+            Copy constructor
+            </summary>
+            <param name="source">The source to copy</param>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeResult.Equals(PayrollEngine.Domain.Model.LookupRangeResult)">
+            <summary>Compare two objects</summary>
+            <param name="compare">The object to compare with this</param>
+            <returns>True for objects with the same data</returns>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupRangeResult.ToString">
+            <inheritdoc/>
+        </member>
         <member name="T:PayrollEngine.Domain.Model.LookupSet">
             <summary>
             Lookup including the lookup value
@@ -4498,6 +4601,12 @@
             <param name="valueFieldName">Value field name</param>
             <remarks>The first lookup range value must be zero.</remarks>
             <returns>Summary of all lookup ranges</returns>
+        </member>
+        <member name="M:PayrollEngine.Domain.Model.LookupSetExtensions.BuildRangeBrackets(PayrollEngine.Domain.Model.LookupSet,System.Nullable{System.Decimal})">
+            <summary>Build range brackets with computed upper bounds</summary>
+            <param name="lookup">The lookup set</param>
+            <param name="rangeValue">Optional value to find matching bracket(s)</param>
+            <returns>Lookup range result with all brackets and optional match</returns>
         </member>
         <member name="T:PayrollEngine.Domain.Model.LookupSettings">
             <summary>

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14116,6 +14116,101 @@
         }
       }
     },
+    "/api/tenants/{tenantId}/payrolls/{payrollId}/lookups/ranges": {
+      "get": {
+        "tags": [
+          "Payrolls"
+        ],
+        "operationId": "GetPayrollLookupRanges",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "payrollId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "lookupNames",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "rangeValue",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "regulationDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "evaluationDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "culture",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LookupRangeResult"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/tenants/{tenantId}/payrolls/{payrollId}/reports": {
       "get": {
         "tags": [
@@ -28713,6 +28808,69 @@
           "rangeValue": {
             "type": "number",
             "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LookupRangeBracket": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "lowerBound": {
+            "type": "number",
+            "format": "double"
+          },
+          "upperBound": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "rangeValue": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LookupRangeResult": {
+        "type": "object",
+        "properties": {
+          "lookupName": {
+            "type": "string",
+            "nullable": true
+          },
+          "rangeMode": {
+            "$ref": "#/components/schemas/LookupRangeMode"
+          },
+          "rangeSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "matchingBracket": {
+            "$ref": "#/components/schemas/LookupRangeBracket"
+          },
+          "matchingBrackets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LookupRangeBracket"
+            },
+            "nullable": true
+          },
+          "allBrackets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LookupRangeBracket"
+            },
             "nullable": true
           }
         },


### PR DESCRIPTION
## Summary

- Add a new `GET /api/tenants/{tenantId}/payrolls/{payrollId}/lookups/ranges` endpoint that returns lookup range brackets with computed upper bounds
- Supports both **Threshold** (single matching bracket) and **Progressive** (multiple matching brackets) range modes
- Exposes the range bracket computation logic already present in `LookupSetExtensions` but previously not accessible via the API

## Motivation

Current lookup endpoints return either raw values (without computed bounds) or a single matched value. There is no way to retrieve the complete bracket structure (lower + upper bounds) through the API. This is needed for contribution preview in salary simulation case (For example, giving visibility of the social contribution threshold based on employee cases).

## New endpoint

```
GET /api/tenants/{tid}/payrolls/{pid}/lookups/ranges
  ?lookupNames=X&lookupNames=Y    (required)
  &rangeValue=7200.00              (optional — filters matching bracket(s))
  &regulationDate=...              (optional)
  &evaluationDate=...              (optional)
  &culture=fr-CH                   (optional)
```

Returns `LookupRangeResult[]` with `allBrackets`, `matchingBracket` (threshold), `matchingBrackets` (progressive).

## Changes

| Layer | Files | Description |
|-------|-------|-------------|
| Domain.Model | `LookupRangeBracket.cs`, `LookupRangeResult.cs`, `LookupSetExtensions.cs` | New POCOs + `BuildRangeBrackets()` method |
| Api.Model | `LookupRangeBracket.cs`, `LookupRangeResult.cs` | API DTOs |
| Api.Map | `LookupRangeBracketMap.cs`, `LookupRangeResultMap.cs` | Mapperly mappers |
| Api.Controller | `PayrollController.cs` | Internal controller with business logic |
| Backend.Controller | `PayrollController.cs` | Public route `[HttpGet("{payrollId}/lookups/ranges")]` |

## Test plan

- [x] `dotnet build` passes with TreatWarningsAsErrors
- [x] `dotnet test` passes
- [x] E2E tested via Docker Compose (SQL Server 2022 + backend):
  - Threshold lookup: single `matchingBracket` returned for a given `rangeValue`
  - Progressive lookup: all applicable `matchingBrackets` returned
  - Upper bounds correctly computed from next bracket's lower bound (+ `rangeSize` for last bracket)
  - Error handling: 400 for unknown lookup names, 400 for missing `lookupNames`