### PR TITLE
ci(release): publish multi-arch image (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             GITHUB_TOKEN=${{ secrets.PAT_DISPATCH }}


### PR DESCRIPTION
## Summary

Adds `linux/arm64` to the published image so `ghcr.io/payroll-engine/payrollengine.backend`
ships a **multi-arch manifest** instead of amd64-only.

Closes #17.

## The change (one line)

```diff
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
```

## Why no QEMU is needed

The `Dockerfile` already supports arm64:

- the build stage is pinned to `--platform=$BUILDPLATFORM`, so it runs natively on the runner and **cross-compiles**;
- it branches on `$TARGETARCH` to publish with `--runtime linux-arm64` / `linux-x64`;
- the final stage has **no `RUN`** (only `COPY` + `ENTRYPOINT`).

So buildx cross-builds the arm64 image from the amd64 runner without emulation. The `gha` cache still works per-platform.

## Verified locally

Ran the exact buildx invocation the workflow uses, for both platforms, with `NUGET_SOURCE=nuget.org` (i.e. as an external consumer, no GitHub Packages token):

```bash
docker buildx build --platform linux/amd64,linux/arm64 \
  --build-arg NUGET_SOURCE=nuget.org \
  --output type=oci,dest=out.tar .
```

Result — a proper multi-arch manifest list, **no QEMU**:

```
Manifest list:
  - linux/amd64
  - linux/arm64
```

- Build-stage steps logged as `[linux/arm64->amd64 build ...]` (cross-compiled, native build stage) and `[linux/arm64 build ...]` — no step ever ran under emulation.
- No `qemu` / `exec format error` anywhere in the build log.
- Exit code 0.

(Tested on an Apple Silicon host, so the host/runner arch is mirrored — the same RUN-free cross-build mechanism applies in CI from the amd64 runner.)
